### PR TITLE
Fix signal corruption from VCD id hash collisions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ set(CMAKE_CXX_FLAGS_RELEASE
 "${CMAKE_CXX_FLAGS_RELEASE} -Wall -O3 -g -fpermissive"
 )
 
-set_source_files_properties(vcd2fst.c fstapi.c fastlz.c lz4.c jrb.c PROPERTIES LANGUAGE CXX)
+set_source_files_properties(vcd2fst.cpp fstapi.c fastlz.c lz4.c jrb.c PROPERTIES LANGUAGE CXX)
 
 if (UNIX AND NOT APPLE)
   set (STACK_DETAILS_AUTO_DETECT FALSE CACHE BOOL "Auto detect backward's stack details dependencies")
@@ -39,7 +39,7 @@ add_subdirectory(third_party/backward-cpp)
 target_include_directories(backward_interface INTERFACE /usr/include/libdwarf/)
 
 set(vcd2fst_SRC
-  ${PROJECT_SOURCE_DIR}/vcd2fst.c
+  ${PROJECT_SOURCE_DIR}/vcd2fst.cpp
   ${PROJECT_SOURCE_DIR}/fstapi.c
   ${PROJECT_SOURCE_DIR}/fastlz.c
   ${PROJECT_SOURCE_DIR}/lz4.c

--- a/vcd2fst.cpp
+++ b/vcd2fst.cpp
@@ -430,6 +430,9 @@ int fst_main(char *vname, char *fstname)
     int hash_kill = 0;
     unsigned int hash_max = 0;
     int *node_len_array = NULL;
+    uint64_t bad_changes = 0;
+    uint64_t vars_created = 0;
+    uint64_t aliases = 0;
     int is_popen = 0;
 #ifdef VCD2FST_EXTLOAD_CONV
     int is_extload = 0;
@@ -681,6 +684,13 @@ int fst_main(char *vname, char *fstname)
                 hash_kill = 1;
             }
 
+            if (strlen(st) >= 5) {
+                hash_kill = 1; /* 32-bit base-94 overflows; use string identity */
+            }
+
+            /* save id pointer before strtok advances; tree takes ownership via strdup */
+            const char *vcd_id = st;
+
             nam = strtok(NULL, " \t"); /* name */
             st = strtok(NULL, " \t"); /* $end */
 
@@ -689,7 +699,7 @@ int fst_main(char *vname, char *fstname)
                     *(st - 1) = ' ';
                 }
 
-                node = jrb_find_int(vcd_ids, hash);
+                node = jrb_find_str(vcd_ids, (char *)vcd_id);
                 if (!node) {
                     Jval val;
                     returnedhandle = fstWriterCreateVar(
@@ -701,7 +711,8 @@ int fst_main(char *vname, char *fstname)
                         nam,
                         0);
                     val.i = returnedhandle;
-                    jrb_insert_int(vcd_ids, hash, val)->val2.i = len;
+                    jrb_insert_str(vcd_ids, strdup(vcd_id), val)->val2.i = len;
+                    vars_created++;
                 } else {
                     fstWriterCreateVar(ctx,
                                        vartype,
@@ -710,6 +721,7 @@ int fst_main(char *vname, char *fstname)
                                        node->val2.i,
                                        nam,
                                        node->val.i);
+                    aliases++;
                 }
 
 #if defined(VCD2FST_EXTLOAD_CONV)
@@ -1087,23 +1099,23 @@ int fst_main(char *vname, char *fstname)
     }
 
     if ((!hash_kill) && (vcd_ids)) {
-        unsigned int hash;
+        JRB nit;
 
         node_len_array = (int*) calloc(hash_max + 1, sizeof(int));
 
-        for (hash = 1; hash <= hash_max; hash++) {
-            node = jrb_find_int(vcd_ids, hash);
-            if (node) {
-                node_len_array[hash] = node->val2.i;
-            } else {
-                node_len_array[hash] = 1; /* should never happen */
+        jrb_traverse(nit, vcd_ids) {
+            /* In canonical mode handle == hash, so index by handle */
+            unsigned int h = (unsigned int)nit->val.i;
+            if (h <= hash_max) {
+                node_len_array[h] = nit->val2.i;
             }
+            free(nit->key.s);
         }
 
         jrb_free_tree(vcd_ids);
         vcd_ids = NULL;
     } else {
-        hash_kill = 1; /* scan-build */
+        hash_kill = 1; /* scan-build; also keeps string tree alive for non-canonical path */
     }
 
     for (;;) /* was while(!feof(f)) */
@@ -1115,7 +1127,12 @@ int fst_main(char *vname, char *fstname)
 
         ss = getline_replace(&wbuf, &buf, &glen, f);
         if (!ss) {
-            break;
+            if (feof(f) || ferror(f)) {
+                break;
+            }
+            /* line starting with a NUL byte: malformed, not EOF */
+            bad_changes++;
+            continue;
         }
 
         nl = buf;
@@ -1132,14 +1149,19 @@ int fst_main(char *vname, char *fstname)
             case '1':
             case 'x':
             case 'z':
-                hash = vcdid_hash(buf + 1, nl - (buf + 1));
                 if (!hash_kill) {
-                    fstWriterEmitValueChange(ctx, hash, buf);
+                    hash = vcdid_hash(buf + 1, nl - (buf + 1));
+                    if (hash >= 1 && hash <= hash_max) {
+                        fstWriterEmitValueChange(ctx, hash, buf);
+                    } else {
+                        bad_changes++;
+                    }
                 } else {
-                    node = jrb_find_int(vcd_ids, hash);
+                    node = jrb_find_str(vcd_ids, buf + 1);
                     if (node) {
                         fstWriterEmitValueChange(ctx, node->val.i, buf);
                     } else {
+                        bad_changes++;
                     }
                 }
                 break;
@@ -1160,11 +1182,17 @@ int fst_main(char *vname, char *fstname)
                 }
             }
 
-                if (!sp)
+                if (!sp) {
+                    bad_changes++;
                     break;
+                }
                 *sp = 0;
                 hash = vcdid_hash(sp + 1, nl - (sp + 1));
                 if (!hash_kill) {
+                    if (hash < 1 || hash > hash_max) {
+                        bad_changes++;
+                        break;
+                    }
                     int bin_len = sp - (buf + 1); /* strlen(buf+1) */
                     int node_len = node_len_array[hash];
 
@@ -1183,7 +1211,7 @@ int fst_main(char *vname, char *fstname)
                         fstWriterEmitValueChange(ctx, hash, bin_fixbuff);
                     }
                 } else {
-                    node = jrb_find_int(vcd_ids, hash);
+                    node = jrb_find_str(vcd_ids, sp + 1);
                     if (node) {
                         int bin_len = sp - (buf + 1); /* strlen(buf+1) */
                         int node_len = node->val2.i;
@@ -1202,29 +1230,37 @@ int fst_main(char *vname, char *fstname)
                             fstWriterEmitValueChange(ctx, node->val.i, bin_fixbuff);
                         }
                     } else {
+                        bad_changes++;
                     }
                 }
                 break;
 
             case 's':
                 sp = strchr(buf, ' ');
-                if (!sp)
+                if (!sp) {
+                    bad_changes++;
                     break;
+                }
                 *sp = 0;
                 hash = vcdid_hash(sp + 1, nl - (sp + 1));
                 if (!hash_kill) {
+                    if (hash < 1 || hash > hash_max) {
+                        bad_changes++;
+                        break;
+                    }
                     int bin_len = sp - (buf + 1); /* strlen(buf+1) */
 
                     bin_len = fstUtilityEscToBin(NULL, (unsigned char *)(buf + 1), bin_len);
                     fstWriterEmitVariableLengthValueChange(ctx, hash, buf + 1, bin_len);
                 } else {
-                    node = jrb_find_int(vcd_ids, hash);
+                    node = jrb_find_str(vcd_ids, sp + 1);
                     if (node) {
                         int bin_len = sp - (buf + 1); /* strlen(buf+1) */
 
                         bin_len = fstUtilityEscToBin(NULL, (unsigned char *)(buf + 1), bin_len);
                         fstWriterEmitVariableLengthValueChange(ctx, node->val.i, buf + 1, bin_len);
                     } else {
+                        bad_changes++;
                     }
                 }
                 break;
@@ -1256,42 +1292,60 @@ int fst_main(char *vname, char *fstname)
                 *pnt = 0;
 
                 sp = strchr(bin_fixbuff, ' ');
-                if (!sp)
+                if (!sp) {
+                    bad_changes++;
                     break;
+                }
                 sp = strchr(sp + 1, ' ');
-                if (!sp)
+                if (!sp) {
+                    bad_changes++;
                     break;
+                }
                 sp = strchr(sp + 1, ' ');
-                if (!sp)
+                if (!sp) {
+                    bad_changes++;
                     break;
+                }
                 *sp = 0;
 
                 hash = vcdid_hash(sp + 1, strlen(sp + 1)); /* nl is no longer good here */
                 if (!hash_kill) {
+                    if (hash < 1 || hash > hash_max) {
+                        bad_changes++;
+                        break;
+                    }
                     fstWriterEmitValueChange(ctx, hash, bin_fixbuff);
                 } else {
-                    node = jrb_find_int(vcd_ids, hash);
+                    node = jrb_find_str(vcd_ids, sp + 1);
                     if (node) {
                         fstWriterEmitValueChange(ctx, node->val.i, bin_fixbuff);
                     } else {
+                        bad_changes++;
                     }
                 }
             } break;
 
             case 'r':
                 sp = strchr(buf, ' ');
-                if (!sp)
+                if (!sp) {
+                    bad_changes++;
                     break;
+                }
                 hash = vcdid_hash(sp + 1, nl - (sp + 1));
                 if (!hash_kill) {
+                    if (hash < 1 || hash > hash_max) {
+                        bad_changes++;
+                        break;
+                    }
                     sscanf(buf + 1, "%lg", &doub);
                     fstWriterEmitValueChange(ctx, hash, &doub);
                 } else {
-                    node = jrb_find_int(vcd_ids, hash);
+                    node = jrb_find_str(vcd_ids, sp + 1);
                     if (node) {
                         sscanf(buf + 1, "%lg", &doub);
                         fstWriterEmitValueChange(ctx, node->val.i, &doub);
                     } else {
+                        bad_changes++;
                     }
                 }
                 break;
@@ -1301,14 +1355,19 @@ int fst_main(char *vname, char *fstname)
             case 'w':
             case 'l':
             case '-':
-                hash = vcdid_hash(buf + 1, nl - (buf + 1));
                 if (!hash_kill) {
-                    fstWriterEmitValueChange(ctx, hash, buf);
+                    hash = vcdid_hash(buf + 1, nl - (buf + 1));
+                    if (hash >= 1 && hash <= hash_max) {
+                        fstWriterEmitValueChange(ctx, hash, buf);
+                    } else {
+                        bad_changes++;
+                    }
                 } else {
-                    node = jrb_find_int(vcd_ids, hash);
+                    node = jrb_find_str(vcd_ids, buf + 1);
                     if (node) {
                         fstWriterEmitValueChange(ctx, node->val.i, buf);
                     } else {
+                        bad_changes++;
                     }
                 }
                 break;
@@ -1337,6 +1396,17 @@ int fst_main(char *vname, char *fstname)
 
     fstWriterClose(ctx);
 
+    fprintf(stderr, "vcd2fst: %llu vars, %llu aliases, last time %llu\n",
+            (unsigned long long)vars_created,
+            (unsigned long long)aliases,
+            (unsigned long long)prev_tim);
+    if (bad_changes) {
+        fprintf(stderr,
+                "vcd2fst: WARNING: %llu value-change line(s) had "
+                "undeclared/malformed ids and were dropped\n",
+                (unsigned long long)bad_changes);
+    }
+
 #if defined(VCD2FST_EXTLOAD_CONV)
     if (xc) {
         fstReaderClose(xc);
@@ -1344,6 +1414,11 @@ int fst_main(char *vname, char *fstname)
 #endif
 
     if (vcd_ids) {
+        /* free strdup'd keys in the string tree */
+        JRB nit;
+        jrb_traverse(nit, vcd_ids) {
+            free(nit->key.s);
+        }
         jrb_free_tree(vcd_ids);
         vcd_ids = NULL;
     }
@@ -1363,7 +1438,7 @@ int fst_main(char *vname, char *fstname)
         }
     }
 
-    return (0);
+    return (bad_changes ? 1 : 0);
 }
 
 void print_help(char *nam)
@@ -1560,10 +1635,10 @@ int main(int argc, char **argv)
         print_help(argv[0]);
     }
 
-    fst_main(vname, lxname);
+    int rc = fst_main(vname, lxname);
 
     free(vname);
     free(lxname);
 
-    return (0);
+    return rc;
 }


### PR DESCRIPTION
## Bug

`vcdid_hash()` interprets a VCD identifier code as a base-94 number in a 32-bit unsigned and uses that value as the signal's identity (the key of the `vcd_ids` JRB tree, and on the fast path the FST handle itself). Ids of 5+ characters can exceed 32 bits (`94^5 > 2^32`), so distinct ids can collide. On collision:

- The second `$var` is treated as an alias of the first: `fstWriterCreateVar` is called with the first signal's width and handle, permanently merging two unrelated signals.
- The colliding signal's value changes are routed to the wrong handle. For scalar changes the whole line buffer is passed as the value, so a 1-bit change like `x-;8~#V` written to a falsely-aliased 20-bit handle stores `x-;8~#V\0\0...` as the payload.
- The tool exits 0, so nothing downstream notices.

Long ids are legal: IEEE 1364/1800 define an identifier code as one or more printable ASCII characters with no length limit. dsim assigns ids by structure (`<group code>~<member index>`), which is spec-compliant but sparse; in a chip-level OpenTitan dump ~55% of ids are 5+ characters at only 531k signals. Tools that emit a dense sequential counter (gtkwave, Icarus) only reach 5-character ids past ~78M signals, which is why the bug stayed latent. Upstream gtkwave master has the identical code as of 2026-06-11, in case Silimate wants to upstream this fix.

Real-world impact: dsim chip-level OpenTitan VCDs (~1.1M vars, 531,163 unique ids, ids up to 7 chars) produce exactly 11 colliding pairs, which corrupted all 65 FSTs in our opentitan-bugbench dataset. Example observed merge: `u_rv_plic...ip[118].d` (1-bit, id `-;8~#V`) aliased onto `u_i2c1...host_timeout_ctrl.q` (20-bit, id `#j>~2`), leaving the 20-bit register's time-0 value as `bx-;8~#V\0\0...`.

## Fix

`vcd2fst.cpp`:

- Key `vcd_ids` by the id string (`jrb_find_str`/`jrb_insert_str`) instead of the 32-bit hash, in both the declaration path and all value-change branches. Any id of 5+ characters forces the non-canonical path (`hash_kill = 1`). The canonical fast path (dense sequential ids, provably collision-free) still emits by hash and gains only a bounds check; `node_len_array` is now built by traversing the string tree (`handle == hash` in canonical mode).
- Loud failure: value-change lines with undeclared ids, malformed structure, out-of-range hashes, or a NUL first byte are counted in `bad_changes`; the tool prints a warning and exits nonzero if any occurred. The out-of-range check also closes an unvalidated `node_len_array[hash]` read. A NUL-prefixed line previously terminated the read loop as if EOF, silently dropping all remaining data with exit 0; it is now counted and skipped.
- End-of-run summary on stderr (vars created, aliases, last timestamp) so calling harnesses can validate conversions.

`CMakeLists.txt`: `vcd2fst.c` -> `vcd2fst.cpp`. The source was renamed in ca3f081 but CMake still referenced the old name, so a clean configure failed.

## Validation

All tests compare this branch against main (plus the CMake one-liner so it builds).

Synthetic collision (ids `#j>~2` w=20 and `-;8~#V` w=1, which collide): old binary produces a corrupt FST (binary garbage in the dump); new binary produces two distinct signals with correct widths and values, exit 0.

Malformed input (VCD with an embedded-NUL value-change line): no crash, warning printed, exit 1, both valid signals and all their changes converted.

Full scale, 8.7 GB dsim chip-level OpenTitan VCD (680,823 `$var`s, 531,163 unique ids, end time 2008149174):

- Conversion exits 0; summary reports 531,163 vars, 149,660 aliases, last time 2008149174. Every unique id gets its own handle (max handle 531,163; the old corrupt FST had 531,152, one short per colliding pair).
- `fstinfo`: end time 2008149174, var count 680,823.
- `fst2vcd | stream validator`: 891M lines, 0 malformed, 0 NUL, last timestamp 2008149174 (the old FST's stream contains NUL-garbage lines).
- All 22 colliding ids resolve to 22 distinct handles with the raw VCD's widths.
- Time-0 spot check: `host_timeout_ctrl.q` reads `bxxxxxxxxxxxxxxxxxxxx` matching the raw VCD (the old FST stores `bx-;8~#V\0\0...`); `ip` bit reads `x`.

Canonical-path regression (8.2 GB `fst2vcd` round-trip VCD, dense ids, stays on the fast path): old 1:17.0, new 1:17.3 wall, identical `fstinfo` (end time, var count, max handle 531,163).

Performance on the non-canonical path (the 8.7 GB dsim VCD): old 2:38, new 4:37 wall (1.75x). The added cost is the per-change string lookup that replaces the colliding int lookup; peak RSS goes from 334 MB to 351 MB. If this matters for large batch conversions, a 64-bit key (collision-free for ids up to 9 chars) can recover most of it as a follow-up.

One behavioral note: conversions that previously "succeeded" by silently dropping data now exit nonzero. On the corrupt-FST-derived stream above, the old binary stopped at the first NUL-prefixed line (last time 0, exit 0); the new binary converts everything (last time 2008149174), reports 35 dropped lines, and exits 1.